### PR TITLE
Adding tor hidden address by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 
 up: ## Build and run the required containers by fetching binaries
 	docker-compose -f docker-compose.yaml up -d
+	docker-compose -f docker-compose.yaml exec tor cat /var/lib/tor/monero/hostname
 
 up-full: ## Build and run the required containers by compiling source
 	docker-compose -f docker-compose.full.yaml up -d
@@ -29,3 +30,6 @@ logs: ## Get logs from the containers
 
 logs-full: ## Get logs from the containers
 	docker-compose -f docker-compose.full.yaml logs -f monerod
+
+tor: ## Get onion address for the Monero node
+	docker-compose -f docker-compose.yaml exec tor cat /var/lib/tor/monero/hostname

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,6 @@ logs-full: ## Get logs from the containers
 
 tor: ## Get onion address for the Monero node
 	docker-compose -f docker-compose.yaml exec tor cat /var/lib/tor/monero/hostname
+
+post: ## Post onion address to monero.fail
+	docker-compose -f docker-compose.yaml exec tor bash /post.sh

--- a/docker-compose.full.yaml
+++ b/docker-compose.full.yaml
@@ -52,6 +52,19 @@ services:
       PORT: 8080
     ports:
       - 127.0.0.1:8080:8080
+  tor:
+    container_name: tor
+    build:
+      context: dockerfiles
+      dockerfile: tor
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:9050:9050
+    volumes:
+      - tor:/var/lib/tor
+    networks:
+      monero:
+        ipv4_address: 172.96.0.15
   monerod:
     container_name: monerod
     build:
@@ -62,6 +75,9 @@ services:
     restart: unless-stopped
     volumes:
       - ${DATA_DIR:-./data}:/data
+    networks:
+      monero:
+        ipv4_address: 172.96.0.20
     ports:
       - ${P2P_PORT:-18080}:18080                    # p2p
       - ${RESTRICTED_PORT:-18081}:18081             # restricted rpc
@@ -69,3 +85,10 @@ services:
       - 127.0.0.1:${UNRESTRICTED_PORT:-18083}:18083 # unrestricted rpc
     command:
       monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist
+networks:
+  monero:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.96.0.0/16

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 volumes:
   grafana:
   prometheus:
+  tor:
 services:
   prometheus:
     image: prom/prometheus:v2.18.0
@@ -54,6 +55,19 @@ services:
       PORT: 8080
     ports:
       - 127.0.0.1:8080:8080
+  tor:
+    container_name: tor
+    build:
+      context: dockerfiles
+      dockerfile: tor
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:9050:9050
+    volumes:
+      - tor:/var/lib/tor
+    networks:
+      monero:
+        ipv4_address: 172.96.0.15
   monerod:
     container_name: monerod
     build:
@@ -62,10 +76,20 @@ services:
     restart: unless-stopped
     volumes:
       - ${DATA_DIR:-./data}:/data
+    networks:
+      monero:
+        ipv4_address: 172.96.0.20
     ports:
       - ${P2P_PORT:-18080}:18080                    # p2p
       - ${RESTRICTED_PORT:-18081}:18081             # restricted rpc
       - 127.0.0.1:${ZMQ_PORT:-18082}:18082          # zmq
       - 127.0.0.1:${UNRESTRICTED_PORT:-18083}:18083 # unrestricted rpc
     command:
-      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist
+      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --tx-proxy tor,172.96.0.15:9050
+networks:
+  monero:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.96.0.0/16

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
       dockerfile: tor
     restart: unless-stopped
     ports:
-      - 127.0.0.1:9050:9050
+      - 127.0.0.1:9051:9051
     volumes:
       - tor:/var/lib/tor
     networks:
@@ -85,7 +85,7 @@ services:
       - 127.0.0.1:${ZMQ_PORT:-18082}:18082          # zmq
       - 127.0.0.1:${UNRESTRICTED_PORT:-18083}:18083 # unrestricted rpc
     command:
-      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --tx-proxy tor,172.96.0.15:9050
+      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --tx-proxy tor,172.96.0.15:9051
 networks:
   monero:
     driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
     ports:
       - 127.0.0.1:8080:8080
   tor:
-    container_name: tor
+    container_name: monerod_tor
     build:
       context: dockerfiles
       dockerfile: tor

--- a/dockerfiles/conf/post.sh
+++ b/dockerfiles/conf/post.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+ONION_ADDR=$(cat /var/lib/tor/monero/hostname)
+ONION_URL="http://${ONION_ADDR}:18081"
+
+curl -q -X POST https://monero.fail/add -d node_url=${ONION_URL}

--- a/dockerfiles/conf/torrc
+++ b/dockerfiles/conf/torrc
@@ -1,0 +1,16 @@
+BridgeRelay 1
+ControlSocket /run/tor/control
+ControlSocketsGroupWritable 1
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+CookieAuthFile /run/tor/control.authcookie
+DataDirectory /var/lib/tor
+ExitPolicy reject6 *:*, reject *:*
+ExitRelay 0
+IPv6Exit 0
+Log notice stdout
+ORPort 9001
+PublishServerDescriptor 0
+SOCKSPort 0.0.0.0:9050
+HiddenServiceDir /var/lib/tor/monero
+HiddenServicePort 18081 172.96.0.20:18081

--- a/dockerfiles/conf/torrc
+++ b/dockerfiles/conf/torrc
@@ -11,6 +11,6 @@ IPv6Exit 0
 Log notice stdout
 ORPort 9001
 PublishServerDescriptor 0
-SOCKSPort 0.0.0.0:9050
+SOCKSPort 0.0.0.0:9051
 HiddenServiceDir /var/lib/tor/monero
 HiddenServicePort 18081 172.96.0.20:18081

--- a/dockerfiles/tor
+++ b/dockerfiles/tor
@@ -1,12 +1,14 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install tor -y
+RUN apt-get update && apt-get install tor curl -y
 
 RUN mkdir -p /run/tor \
   && chown -R debian-tor:debian-tor /run/tor \
   && chmod 700 -R /run/tor
 
 COPY conf/torrc /etc/tor/torrc
+
+COPY conf/post.sh /post.sh
 
 USER debian-tor
 

--- a/dockerfiles/tor
+++ b/dockerfiles/tor
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install tor -y
+
+RUN mkdir -p /run/tor \
+  && chown -R debian-tor:debian-tor /run/tor \
+  && chmod 700 -R /run/tor
+
+COPY conf/torrc /etc/tor/torrc
+
+USER debian-tor
+
+EXPOSE 9050
+
+ENTRYPOINT ["tor"]


### PR DESCRIPTION
Couldn't figure out how to setup `--anonymous-inbound` on the monerod container, but this is a first pass that will expose the restricted RPC port to the Tor network.