### PR TITLE
Allow nodemapper to listen on IPv6 in additon to IPv4

### DIFF
--- a/dockerfiles/nodemapper
+++ b/dockerfiles/nodemapper
@@ -10,4 +10,4 @@ RUN wget https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb 
 
 COPY dockerfiles/nodemapper.py app.py
 
-ENTRYPOINT [ ".venv/bin/flask", "--app", "app", "run", "--host", "0.0.0.0" ]
+ENTRYPOINT [ ".venv/bin/flask", "--app", "app", "run", "--host", "::" ]


### PR DESCRIPTION
nodemapper is hard-coded to listen only on IPv4 addresses. This pull request changes `--host` to `::` instead of `0.0.0.0`. This causes flask to respond to both address families. While specifying `:: `may look as if it's configured to ONLY listed on IPv6 addresses, that is not the case with flask. `::` is equivalent to "listen on all interfaces"

See[ here](http://stackoverflow.com/questions/21673068/dual-ipv4-and-ipv6-support-in-flask-applications) for additional information on how flask handles dual-stack.