### PR TITLE
Add spy node ban list

### DIFF
--- a/docker-compose.full.yaml
+++ b/docker-compose.full.yaml
@@ -91,5 +91,5 @@ services:
       - 127.0.0.1:${ZMQ_PORT:-18082}:18082          # zmq
       - 127.0.0.1:${UNRESTRICTED_PORT:-18083}:18083 # unrestricted rpc
     command:
-      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --rpc-ssl=disabled
+      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --rpc-ssl=disabled --ban-list=/ban_list.txt
     <<: *log-config

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,5 +91,5 @@ services:
       - 127.0.0.1:${ZMQ_PORT:-18082}:18082          # zmq
       - 127.0.0.1:${UNRESTRICTED_PORT:-18083}:18083 # unrestricted rpc
     command:
-      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --rpc-ssl=disabled
+      monerod --data-dir=/data --p2p-bind-ip=0.0.0.0 --p2p-bind-port=18080 --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18081 --zmq-rpc-bind-ip=0.0.0.0 --zmq-rpc-bind-port=18082 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18083 --non-interactive --confirm-external-bind --public-node --log-level=0 --enable-dns-blocklist --rpc-ssl=disabled --ban-list=/ban_list.txt
     <<: *log-config

--- a/dockerfiles/monero
+++ b/dockerfiles/monero
@@ -8,10 +8,13 @@ ENV MONERO_SUMS_FILE sha256sums
 WORKDIR /opt/monero
 
 # Update system and install dependencies
+# Download ban list
 # Download Monero binaries from getmonero.org
 # Confirm hashes match
 # Install daemon binary
 # Clean up
+
+RUN wget -qO /ban_list.txt "https://raw.githubusercontent.com/Boog900/monero-ban-list/main/ban_list.txt"
 
 RUN apt-get update \
   && apt-get upgrade -y \
@@ -37,6 +40,7 @@ WORKDIR /data
 # Copy to fresh Ubuntu image to reduce size
 FROM ubuntu:22.04
 COPY --from=OG /usr/local/bin/monerod /usr/local/bin/monerod
+COPY --from=OG /ban_list.txt /ban_list.txt
 
 EXPOSE 18080
 EXPOSE 18081

--- a/dockerfiles/monero
+++ b/dockerfiles/monero
@@ -14,11 +14,11 @@ WORKDIR /opt/monero
 # Install daemon binary
 # Clean up
 
-RUN wget -qO /ban_list.txt "https://raw.githubusercontent.com/Boog900/monero-ban-list/main/ban_list.txt"
-
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y tar wget bzip2
+  
+RUN wget -qO /ban_list.txt "https://raw.githubusercontent.com/Boog900/monero-ban-list/main/ban_list.txt"
 
 RUN wget -qO ${MONERO_DL_FILE} ${MONERO_DL_URL} \
   && echo "${MONERO_HASH}  ${MONERO_DL_FILE}" > ${MONERO_SUMS_FILE} \


### PR DESCRIPTION
> The Monero Research Lab (MRL) https://github.com/monero-project/meta/issues/1119 to recommend that all Monero node operators enable a ban list of suspected spy node IP addresses. The spy nodes can reduce the privacy of Monero users.

https://github.com/monero-project/meta/issues/1124