### PR TITLE
no chain sync over proxy

### DIFF
--- a/docker-compose.full.yaml
+++ b/docker-compose.full.yaml
@@ -159,7 +159,6 @@ services:
       - --public-node
       - --log-level=0
       - --rpc-ssl=disabled
-      - --proxy=172.31.255.250:9050
       - --ban-list=/ban_list.txt
       - --tx-proxy=tor,172.31.255.250:9050,disable_noise,24
       - --tx-proxy=i2p,172.31.255.251:4447,disable_noise,24

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,7 +153,6 @@ services:
       - --public-node
       - --log-level=0
       - --rpc-ssl=disabled
-      - --proxy=172.31.255.250:9050
       - --ban-list=/ban_list.txt
       - --tx-proxy=tor,172.31.255.250:9050,disable_noise,24
       - --tx-proxy=i2p,172.31.255.251:4447,disable_noise,24


### PR DESCRIPTION
`--proxy` means the chain is downloaded over tor or i2p, which is painfully slow and bogs down those networks. remove this from default behavior.