### PR TITLE
fix `torrc` permissions

### DIFF
--- a/dockerfiles/tor
+++ b/dockerfiles/tor
@@ -7,6 +7,7 @@ RUN mkdir -p /run/tor /var/lib/tor/monerod /var/lib/tor/monerod-rpc \
   && chmod 700 -R /run/tor /var/lib/tor/monerod /var/lib/tor/monerod-rpc
 
 COPY dockerfiles/tor-config /etc/tor/torrc
+RUN chmod 644 /etc/tor/torrc
 
 USER debian-tor
 


### PR DESCRIPTION
On one of my machines when I clone the repo the `tor-config` file gets the permissions `600` so when the tor container starts it can't read the `torrc` file and the hidden service never starts. This is the warning I get from the tor container:
```
[warn] Could not open "/etc/tor/torrc": Permission denied
[notice] Configuration file "/etc/tor/torrc" not present, using reasonable defaults.
```

I think this could be useful for anyone else that also has restrictive permissions.